### PR TITLE
all elements need to be defined as page-template custom elements

### DIFF
--- a/src/templates/blog-template.js
+++ b/src/templates/blog-template.js
@@ -16,4 +16,4 @@ class BlogTemplate extends LitElement {
   }
 }
 
-customElements.define('blog-template', BlogTemplate);
+customElements.define('page-template', BlogTemplate);


### PR DESCRIPTION
looks like every page template needs to be defined as such
```javascript
customElements.define('page-template', MyComponentClass);
```

Will need to update the docs.  Not sure if expected, but can chat about this more in Slack.